### PR TITLE
Add openjdk and fixed R module file.

### DIFF
--- a/modulefiles/.modulespath
+++ b/modulefiles/.modulespath
@@ -1,6 +1,4 @@
 /software/modulefiles
 /software/builds/intel/2024.2/etc/modulefiles
 /software/modulefiles/StdEnv.lua
-#/software/spack/v1.0/modules/linux-rocky9-x86_64/gcc/13.4.0
-#/software/spack/v1.0/modules/linux-rocky9-x86_64/Core
 /software/spack/v1.1.1/modules/linux-rocky9-x86_64/Core

--- a/modulefiles/.modulespath
+++ b/modulefiles/.modulespath
@@ -1,5 +1,6 @@
 /software/modulefiles
 /software/builds/intel/2024.2/etc/modulefiles
 /software/modulefiles/StdEnv.lua
-/software/spack/latest/modules/linux-rocky9-x86_64/gcc/13.4.0
-/software/spack/latest/modules/linux-rocky9-x86_64/Core
+#/software/spack/v1.0/modules/linux-rocky9-x86_64/gcc/13.4.0
+#/software/spack/v1.0/modules/linux-rocky9-x86_64/Core
+/software/spack/v1.1.1/modules/linux-rocky9-x86_64/Core

--- a/modulefiles/R/4.5.1-gcc-13.4.0.lua
+++ b/modulefiles/R/4.5.1-gcc-13.4.0.lua
@@ -1,0 +1,10 @@
+whatis([===[Provide the environment variables to run R version 4.5.1 compiled with openmpi-4.0 and GCC 13.4.0.]===])
+depends_on("gcc/13.4.0")
+depends_on("openmpi/4.1.8-gcc-13.4.0")
+depends_on("openjdk/17.0.11_9-none-none")
+setenv("RHOME","/software/R/4.5.1/lib64/R/")
+prepend_path{"LD_LIBRARY_PATH","/software/R/4.5.1/lib64/R/lib",delim=":",priority="0"}
+prepend_path{"MANPATH","/software/R/4.5.1/share/man",delim=":",priority="0"}
+prepend_path{"PATH","/software/R/4.5.1/bin",delim=":",priority="0"}
+setenv("TMPDIR", os.getenv("HOME") .. "/Rtmp")
+os.execute("mkdir -p $HOME/Rtmp")

--- a/spack/v1.1.1/spack.yaml
+++ b/spack/v1.1.1/spack.yaml
@@ -1,4 +1,3 @@
-
 # This is a Spack Environment file.
 #
 # It describes a set of packages to be installed, along with
@@ -22,6 +21,8 @@ spack:
   - libxcb@1.17.0
   - boost@1.88.0
   - texlive@20250308
+  - openblas@0.3.30
+  - openjdk@17.0.11_9
   view: false
 #    prod:
 #      root: /software/spack/v1.0/view
@@ -67,7 +68,7 @@ spack:
         hide_implicits: true
         #all:
         #  autoload: direct # or `run`
-        hash_length: 0 
+        hash_length: 0
         projections:
           all: '{name}/{version}-{compiler.name}-{compiler.version}'
           gcc: '{name}/{version}'


### PR DESCRIPTION
The R module needed a java module which was missing from Spack.  Added openjdk to Spack and updated the R module file with the correct version.