### PR TITLE
Default Spack package repo version

### DIFF
--- a/spack/defaults/config/repos.yaml
+++ b/spack/defaults/config/repos.yaml
@@ -13,4 +13,4 @@
 repos:
   builtin:
     git: https://github.com/spack/spack-packages.git
-    branch: releases/v2025.07
+    tag: v2025.11.0


### PR DESCRIPTION
This version matches the package repo version used in the cluster-wide upstream